### PR TITLE
Filter all custom-metrics related resources out of the manifest.

### DIFF
--- a/cmd/manager/kodata/knative-serving/0.11.1.yaml
+++ b/cmd/manager/kodata/knative-serving/0.11.1.yaml
@@ -1743,22 +1743,6 @@ spec:
       serviceAccountName: controller
 
 ---
-apiVersion: apiregistration.k8s.io/v1beta1
-kind: APIService
-metadata:
-  labels:
-    autoscaling.knative.dev/metric-provider: custom-metrics
-    serving.knative.dev/release: "v0.11.1"
-  name: v1beta1.custom.metrics.k8s.io
-spec:
-  group: custom.metrics.k8s.io
-  groupPriorityMinimum: 100
-  insecureSkipTLSVerify: true
-  service:
-    name: autoscaler
-    namespace: knative-serving
-  version: v1beta1
-  versionPriority: 100
 
 ---
 

--- a/cmd/manager/kodata/knative-serving/0.11.1.yaml
+++ b/cmd/manager/kodata/knative-serving/0.11.1.yaml
@@ -32,20 +32,6 @@ rules:
 ---
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    autoscaling.knative.dev/metric-provider: custom-metrics
-    serving.knative.dev/release: "v0.11.1"
-  name: custom-metrics-server-resources
-rules:
-- apiGroups:
-  - custom.metrics.k8s.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -262,38 +248,8 @@ metadata:
   namespace: knative-serving
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    autoscaling.knative.dev/metric-provider: custom-metrics
-    serving.knative.dev/release: "v0.11.1"
-  name: custom-metrics:system:auth-delegator
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:auth-delegator
-subjects:
-- kind: ServiceAccount
-  name: controller
-  namespace: knative-serving
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    autoscaling.knative.dev/metric-provider: custom-metrics
-    serving.knative.dev/release: "v0.11.1"
-  name: hpa-controller-custom-metrics
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: custom-metrics-server-resources
-subjects:
-- kind: ServiceAccount
-  name: horizontal-pod-autoscaler
-  namespace: kube-system
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -312,22 +268,6 @@ subjects:
   namespace: knative-serving
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
-    autoscaling.knative.dev/metric-provider: custom-metrics
-    serving.knative.dev/release: "v0.11.1"
-  name: custom-metrics-auth-reader
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: extension-apiserver-authentication-reader
-subjects:
-- kind: ServiceAccount
-  name: controller
-  namespace: knative-serving
 
 ---
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://issues.redhat.com/browse/SRVKS-397

## Proposed Changes

Filter out all resources that have something to do with custom-metrics, especially the API service as that doesn't work on Openshift properly yet.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @jcrossley3 
