### PR TITLE
[SRVKS-452] Bump webhook memory limit to 1G.

### DIFF
--- a/cmd/manager/kodata/knative-serving/0.13.0.yaml
+++ b/cmd/manager/kodata/knative-serving/0.13.0.yaml
@@ -1351,7 +1351,7 @@ spec:
             memory: 20Mi
           limits:
             cpu: 200m
-            memory: 200Mi
+            memory: 1024Mi
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:


### PR DESCRIPTION
The linked JIRA has all the context. Unfortunately our webhook currently scales fairly linearly with namespaces so this would in theory allow ~1000 namespaces which sounds sufficient to me for the time being.
