### PR TITLE
[BACKPORT] Removes write access to the internal resources from aggregated cluserroles

### DIFF
--- a/cmd/manager/kodata/knative-serving/0.13.2.yaml
+++ b/cmd/manager/kodata/knative-serving/0.13.2.yaml
@@ -2019,10 +2019,12 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     serving.knative.dev/release: "v0.13.2"
 rules:
-- apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev",
-    "caching.internal.knative.dev"]
+- apiGroups: ["serving.knative.dev"]
   resources: ["*"]
   verbs: ["*"]
+- apiGroups: ["networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2032,10 +2034,12 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     serving.knative.dev/release: "v0.13.2"
 rules:
-- apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev",
-    "caching.internal.knative.dev"]
+- apiGroups: ["serving.knative.dev"]
   resources: ["*"]
   verbs: ["create", "update", "patch", "delete"]
+- apiGroups: ["networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Proposed Changes

This patch removes power to create/edit "internal" resources from
namespaced users.

The internal resources should be created/edit by only controller and
users should not create it manually.

The upstream fix is here: https://github.com/knative/serving/commit/3d224fb4fbf8779ddfffd509731f9407101a1e3a
